### PR TITLE
feat: add structural and comment-based KO components with test and export support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jsdom": "^26.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.9"
   }
 }

--- a/src/components/structural/KoForeach.tsx
+++ b/src/components/structural/KoForeach.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { KnockoutScope } from '../../KnockoutScope'
+
+type Props = {
+  items: KnockoutObservable<unknown[]> | unknown[]
+  children: React.ReactNode
+}
+
+/**
+ * Renders children for each item in the given array.
+ * Uses Knockout's `foreach:` binding internally.
+ */
+export const KoForeach = React.memo(function KoForeach({ items, children }: Props) {
+  const vm = { items }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <div data-bind="foreach: items">
+        {children}
+      </div>
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/KoIf.tsx
+++ b/src/components/structural/KoIf.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { KnockoutScope } from '../../KnockoutScope'
+
+type Props = {
+  condition: KnockoutObservable<boolean> | boolean
+  children: React.ReactNode
+}
+
+/**
+ * Wraps children with a Knockout `if:` binding using a `div` container.
+ * Safer and more efficient than comment-based bindings in React.
+ * Recommended for standard usage when template compatibility is not required.
+ */
+export const KoIf = React.memo(function KoIf({ condition, children }: Props) {
+  const vm = { condition }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <div data-bind="if: condition"  style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/KoIfNot.tsx
+++ b/src/components/structural/KoIfNot.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { KnockoutScope } from '../../KnockoutScope'
+
+type Props = {
+  condition: KnockoutObservable<boolean> | boolean
+  children: React.ReactNode
+}
+
+/**
+ * Renders children only when the given condition is false.
+ * Uses Knockout's `ifnot:` binding internally.
+ */
+export const KoIfNot = React.memo(function KoIfNot({ condition, children }: Props) {
+  const vm = { condition }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <div data-bind="ifnot: condition" style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/compat/HtmlComment.tsx
+++ b/src/components/structural/compat/HtmlComment.tsx
@@ -1,0 +1,31 @@
+import React, { useLayoutEffect, useRef } from 'react'
+
+type HtmlCommentProps = {
+  text: string
+}
+
+/**
+ * Inserts a standalone HTML comment node into the DOM.
+ * Used to support Knockout comment-based bindings like `ko if:`.
+ * Removes the placeholder div on mount and replaces it with a comment.
+ */
+export const HtmlComment = React.memo(function HtmlComment({ text }: HtmlCommentProps) {
+  const markerRef = useRef<HTMLDivElement | null>(null)
+  useLayoutEffect(() => {
+    const marker = markerRef.current
+    if (marker === null) {
+      return
+    }
+    const parent = marker.parentNode
+    if (parent === null) {
+      return
+    }
+
+    const comment = document.createComment(` ${text} `)
+    parent.insertBefore(comment, marker)
+  }, [text])
+
+  return (
+    <div ref={markerRef} style={{ display: 'none' }}></div>
+  )
+})

--- a/src/components/structural/compat/KoForeachComment.tsx
+++ b/src/components/structural/compat/KoForeachComment.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { KnockoutScope } from '../../../KnockoutScope'
+import { HtmlComment } from './HtmlComment'
+
+type Props = {
+  items: KnockoutObservable<unknown[]> | unknown[]
+  children: React.ReactNode
+}
+
+/**
+ * Renders children with Knockout's comment-based `foreach:` binding.
+ * Useful for template compatibility scenarios.
+ */
+export const KoForeachComment = React.memo(function KoForeachComment({ items, children }: Props) {
+  const vm = { items }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <HtmlComment text="ko foreach: items" />
+      {children}
+      <HtmlComment text="/ko" />
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/compat/KoIfComment.tsx
+++ b/src/components/structural/compat/KoIfComment.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { KnockoutScope } from '../../../KnockoutScope'
+import { HtmlComment } from './HtmlComment'
+
+type Props = {
+  condition: KnockoutObservable<boolean> | boolean
+  children: React.ReactNode
+}
+
+/**
+ * Wraps children with Knockout comment-based `if:` bindings.
+ * Suitable for maintaining compatibility with KO template logic.
+ * Renders `<!-- ko if: condition -->...<!-- /ko -->` around children.
+ */
+export const KoIfComment = React.memo(function KoIfComment({ condition, children }: Props) {
+  const vm = { condition }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <HtmlComment text="ko if: condition" />
+      {children}
+      <HtmlComment text="/ko" />
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/compat/KoIfNotComment.tsx
+++ b/src/components/structural/compat/KoIfNotComment.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { KnockoutScope } from '../../../KnockoutScope'
+import { HtmlComment } from './HtmlComment'
+
+type Props = {
+  condition: KnockoutObservable<boolean> | boolean
+  children: React.ReactNode
+}
+
+/**
+ * Renders children with Knockout's comment-based `ifnot:` binding.
+ * Useful for compatibility with template-based KO structures.
+ */
+export const KoIfNotComment = React.memo(function KoIfNotComment({ condition, children }: Props) {
+  const vm = { condition }
+
+  return (
+    <KnockoutScope viewModel={vm}>
+      <HtmlComment text="ko ifnot: condition" />
+      {children}
+      <HtmlComment text="/ko" />
+    </KnockoutScope>
+  )
+})

--- a/src/components/structural/compat/index.ts
+++ b/src/components/structural/compat/index.ts
@@ -1,0 +1,4 @@
+export { HtmlComment } from './HtmlComment'
+export { KoForeachComment } from './KoForeachComment'
+export { KoIfComment } from './KoIfComment'
+export { KoIfNotComment } from './KoIfNotComment'

--- a/src/components/structural/index.ts
+++ b/src/components/structural/index.ts
@@ -1,0 +1,5 @@
+export { KoForeach } from './KoForeach'
+export { KoIf } from './KoIf'
+export { KoIfNot } from './KoIfNot'
+
+export * from './compat'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { RootKnockoutProvider } from './RootKnockoutProvider'
 export { KnockoutScope } from './KnockoutScope'
 export { AppViewModelContext, useAppViewModel } from './context/AppViewModelContext'
+
+export * from './components/structural'

--- a/tests/components/structural/KoForeach.test.tsx
+++ b/tests/components/structural/KoForeach.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoForeach } from '@/components/structural/KoForeach'
+import { KnockoutScope } from '@/KnockoutScope'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+import ko from 'knockout'
+
+describe('KoForeach', () => {
+  it('renders children for each item in the array', () => {
+    const vm = { items: ko.observableArray(['A', 'B', 'C']) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoForeach items={vm.items}>
+            <span data-bind="text: $data" />
+          </KoForeach>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('A')).toBeDefined()
+    expect(screen.getByText('B')).toBeDefined()
+    expect(screen.getByText('C')).toBeDefined()
+  })
+
+  it('renders nothing when the array is empty', () => {
+    const vm = { items: ko.observableArray([]) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoForeach items={vm.items}>
+            <span data-bind="text: $data" />
+          </KoForeach>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText(/./)).toBeNull()
+  })
+})

--- a/tests/components/structural/KoIf.test.tsx
+++ b/tests/components/structural/KoIf.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoIf } from '@/components/structural/KoIf'
+import { KnockoutScope } from '@/KnockoutScope'
+import ko from 'knockout'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+
+describe('KoIf', () => {
+  it('renders children when condition is true', () => {
+    const vm = { isVisible: ko.observable(true) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIf condition={vm.isVisible}>
+            <p>Visible</p>
+          </KoIf>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('Visible')).toBeDefined()
+  })
+
+  it('does not render children when condition is false', () => {
+    const vm = { isVisible: ko.observable(false) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIf condition={vm.isVisible}>
+            <p>Hidden</p>
+          </KoIf>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText('Hidden')).toBeNull()
+  })
+})

--- a/tests/components/structural/KoIfNot.test.tsx
+++ b/tests/components/structural/KoIfNot.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoIfNot } from '@/components/structural/KoIfNot'
+import { KnockoutScope } from '@/KnockoutScope'
+import ko from 'knockout'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+
+describe('KoIfNot', () => {
+  it('renders children when condition is false', () => {
+    const vm = { isHidden: ko.observable(false) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfNot condition={vm.isHidden}>
+            <p>Not hidden</p>
+          </KoIfNot>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('Not hidden')).toBeDefined()
+  })
+
+  it('does not render children when condition is true', () => {
+    const vm = { isHidden: ko.observable(true) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfNot condition={vm.isHidden}>
+            <p>Hidden</p>
+          </KoIfNot>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText('Hidden')).toBeNull()
+  })
+})

--- a/tests/components/structural/compat/HtmlComment.test.tsx
+++ b/tests/components/structural/compat/HtmlComment.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HtmlComment } from '@/components/structural/compat/HtmlComment'
+
+describe('HtmlComment', () => {
+  it('inserts a comment into the DOM', () => {
+    const text = 'ko ifnot: condition'
+    
+    render(<HtmlComment text={text} />)
+
+    // コメントノードがDOMに含まれているかを確認
+    const comment = document.querySelector('div')?.firstChild
+    expect(comment).not.toBeNull()
+    expect(comment?.nodeType).toBe(Node.COMMENT_NODE)  // コメントノードであることを確認
+    expect(comment?.nodeValue).toBe(` ${text} `)       // コメントの内容が一致することを確認
+  })
+})

--- a/tests/components/structural/compat/KoForeachComment.test.tsx
+++ b/tests/components/structural/compat/KoForeachComment.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoForeachComment } from '@/components/structural/compat/KoForeachComment'
+import { KnockoutScope } from '@/KnockoutScope'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+import ko from 'knockout'
+
+describe('KoForeachComment', () => {
+  it('renders children for each item in the array', () => {
+    const vm = { items: ko.observableArray(['A', 'B', 'C']) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoForeachComment items={vm.items}>
+            <span data-bind="text: $data" />
+          </KoForeachComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('A')).toBeDefined()
+    expect(screen.getByText('B')).toBeDefined()
+    expect(screen.getByText('C')).toBeDefined()
+  })
+
+  it('renders nothing when the array is empty', () => {
+    const vm = { items: ko.observableArray([]) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoForeachComment items={vm.items}>
+            <span data-bind="text: $data" />
+          </KoForeachComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText(/./)).toBeNull()
+  })
+})

--- a/tests/components/structural/compat/KoIfComment.test.tsx
+++ b/tests/components/structural/compat/KoIfComment.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoIfComment } from '@/components/structural/compat/KoIfComment'
+import { KnockoutScope } from '@/KnockoutScope'
+import ko from 'knockout'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+
+describe('KoIfComment', () => {
+  it('renders children when condition is true', () => {
+    const vm = { isVisible: ko.observable(true) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfComment condition={vm.isVisible}>
+            <p>Visible</p>
+          </KoIfComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('Visible')).toBeDefined()
+  })
+
+  it('does not render children when condition is false', () => {
+    const vm = { isVisible: ko.observable(false) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfComment condition={vm.isVisible}>
+            <p>Hidden</p>
+          </KoIfComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText('Hidden')).toBeNull()
+  })
+})

--- a/tests/components/structural/compat/KoIfNotComment.test.tsx
+++ b/tests/components/structural/compat/KoIfNotComment.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KoIfNotComment } from '@/components/structural/compat/KoIfNotComment'
+import { KnockoutScope } from '@/KnockoutScope'
+import ko from 'knockout'
+import { RootKnockoutProvider } from '@/RootKnockoutProvider'
+
+describe('KoIfNotComment', () => {
+  it('renders children when condition is false', () => {
+    const vm = { isHidden: ko.observable(false) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfNotComment condition={vm.isHidden}>
+            <p>Not hidden</p>
+          </KoIfNotComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.getByText('Not hidden')).toBeDefined()
+  })
+
+  it('does not render children when condition is true', () => {
+    const vm = { isHidden: ko.observable(true) }
+
+    render(
+      <RootKnockoutProvider viewModel={{}}>
+        <KnockoutScope viewModel={vm}>
+          <KoIfNotComment condition={vm.isHidden}>
+            <p>Hidden</p>
+          </KoIfNotComment>
+        </KnockoutScope>
+      </RootKnockoutProvider>
+    )
+
+    expect(screen.queryByText('Hidden')).toBeNull()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    },
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
@@ -12,5 +16,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
   test: {
@@ -6,4 +7,5 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
   },
+  plugins: [tsconfigPaths()],
 })


### PR DESCRIPTION
feat: add structural and comment-based KO components with test and export support

- enable `@` alias for path resolution
- add KoIf, KoIfNot, KoForeach components
- add comment-based variants: KoIfComment, KoIfNotComment, KoForeachComment, HtmlComment
- add tests for all structural and compat components
- update index exports for new components